### PR TITLE
Add Docker support for easy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+*.md
+paper/
+images/
+index.html
+index_files/
+__pycache__
+*.pyc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use official TensorFlow 1.15 image (x86_64)
+FROM --platform=linux/amd64 tensorflow/tensorflow:1.15.5-py3
+
+LABEL maintainer="White-box-Cartoonization"
+LABEL description="Docker image for White-box Cartoonization (TensorFlow 1.x)"
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Install system dependencies for OpenCV
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Install additional Python dependencies
+RUN pip install --no-cache-dir \
+    opencv-python==4.5.5.64 \
+    scikit-image==0.14.5 \
+    tqdm>=4.0.0
+
+# Copy the application code
+COPY . .
+
+# Set working directory to test_code for inference
+WORKDIR /app/test_code
+
+# Default command to run cartoonization
+CMD ["python", "cartoonize.py"]

--- a/README.md
+++ b/README.md
@@ -49,9 +49,44 @@
 
 ### Installation
 
-- Assume you already have NVIDIA GPU and CUDA CuDNN installed 
-- Install tensorflow-gpu, we tested 1.12.0 and 1.13.0rc0 
+- Assume you already have NVIDIA GPU and CUDA CuDNN installed
+- Install tensorflow-gpu, we tested 1.12.0 and 1.13.0rc0
 - Install scikit-image==0.14.5, other versions may cause problems
+
+
+### Docker
+
+You can run the cartoonization using Docker without installing any dependencies locally.
+
+#### Build the Docker image
+
+```bash
+docker build --platform linux/amd64 -t whitebox-cartoonization:latest .
+```
+
+#### Run with default test images
+
+```bash
+docker run --rm --platform linux/amd64 whitebox-cartoonization:latest
+```
+
+#### Run with custom images
+
+Mount your input and output directories as volumes:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v /path/to/your/images:/app/test_code/test_images \
+  -v /path/to/output:/app/test_code/cartoonized_images \
+  whitebox-cartoonization:latest
+```
+
+#### Docker environment details
+
+- **Base image:** tensorflow/tensorflow:1.15.5-py3 (Ubuntu 18.04)
+- **Python:** 3.6
+- **TensorFlow:** 1.15.5
+- **Platform:** linux/amd64 (works on Apple Silicon via emulation)
 
 
 ### Inference with Pre-trained Model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+opencv-python==4.5.5.64
+scikit-image==0.14.5
+tqdm>=4.0.0


### PR DESCRIPTION
## Summary
- Add Dockerfile using tensorflow/tensorflow:1.15.5-py3 base image (Ubuntu 18.04, Python 3.6)
- Add requirements.txt with Python dependencies (opencv-python, scikit-image, tqdm)
- Add .dockerignore to exclude unnecessary files from build
- Update README.md with Docker build and run instructions

## Usage

Build the image:
```bash
docker build --platform linux/amd64 -t whitebox-cartoonization:latest .
```

Run with custom images:
```bash
docker run --rm --platform linux/amd64 \
  -v /path/to/your/images:/app/test_code/test_images \
  -v /path/to/output:/app/test_code/cartoonized_images \
  whitebox-cartoonization:latest
```

## Test plan
- [x] Docker image builds successfully
- [x] Cartoonization runs and processes all 11 test images
- [x] Output images are generated correctly